### PR TITLE
manage nan value

### DIFF
--- a/PyFina/PyFina.py
+++ b/PyFina/PyFina.py
@@ -13,8 +13,8 @@ def trim(id, dir, limit=100):
     meta = getMeta(id, dir)
     pos = 0
     i = 0
-    nbn =0
-    with open("{}/{}.dat".format(dir, id), "rb+") as ts:
+    nbn = 0
+    with open(f"{dir}/{id}.dat", "rb+") as ts:
         while pos <= meta["npoints"]:
             ts.seek(pos*4, 0)
             hexa = ts.read(4)
@@ -24,19 +24,19 @@ def trim(id, dir, limit=100):
                 if math.isnan(value):
                     nbn +=1
                 elif value > limit:
-                    print("anomaly detected at {} : {}".format(pos, value))
+                    print(f"anomaly detected at {pos} : {value}")
                     i += 1
                     nv = struct.pack('<f', float('nan'))
                     try:
-                        ts.seek(pos*4,0)
+                        ts.seek(pos*4, 0)
                         ts.write(nv)
                     except Exception as e:
                         print(e)
                     finally:
                         print("4 bytes written")
             pos +=1
-        print("{} anomaly(ies)".format(i))
-        print("{} nan".format(nbn))
+        print(f"{i} anomaly(ies)")
+        print(f"{nbn} nan")
 
 def getMeta(id, dir):
     """

--- a/PyFina/PyFina.py
+++ b/PyFina/PyFina.py
@@ -107,7 +107,7 @@ class PyFina(np.ndarray):
         first_non_nan_index = -1
         if nb_nan < npts:
             finiteness_obj = np.isfinite(raw_obj)
-            first_non_nan_index = np.where(if finiteness_obj:)[0][0]
+            first_non_nan_index = np.where(finiteness_obj)[0][0]
             first_non_nan_value = raw_obj[finiteness_obj][0]
         starting_by_nan = np.isnan(raw_obj[0])
         if starting_by_nan and remove_nan:

--- a/PyFina/PyFina.py
+++ b/PyFina/PyFina.py
@@ -77,7 +77,6 @@ class PyFina(np.ndarray):
         pos = (time - meta["start_time"]) // meta["interval"]
         Nota : no NAN value - if a NAN is detected, the algorithm will fetch the first non NAN value in the future
         """
-        verbose = False
         obj = np.zeros(npts).view(cls)
         raw_obj = np.zeros(npts)
 
@@ -108,7 +107,7 @@ class PyFina(np.ndarray):
         first_non_nan_index = -1
         if nb_nan < npts:
             finiteness_obj = np.isfinite(raw_obj)
-            first_non_nan_index = np.where(finiteness_obj == True)[0][0]
+            first_non_nan_index = np.where(if finiteness_obj:)[0][0]
             first_non_nan_value = raw_obj[finiteness_obj][0]
         starting_by_nan = np.isnan(raw_obj[0])
         if starting_by_nan and remove_nan:
@@ -124,7 +123,8 @@ class PyFina(np.ndarray):
         return obj
 
     def __array_finalize__(self, obj):
-        if obj is None: return
+        if obj is None:
+            return
         self.start = getattr(obj, 'start', None)
         self.step = getattr(obj, 'step', None)
 


### PR DESCRIPTION
previsously, we were inefficiently searching the first non nan value in the future.

if a nan is detected and remove_nan is true, the new code replaces it by the previous value.

if the starting value is a nan, the feed can start by (many) 0 because it is initialized as an array of zeros. But those starting zeros are actually nan Using np.isfinite, the code searches in the future for the first non nan value in the feed and replaces the starting zeros by this value

adding first_non_nan_value, first_non_nan_index and starting_by_nan in the feed signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `remove_nan` parameter to control the handling of NaN values during object creation.
  - NaN values can now be stored separately and replaced with the previous non-NaN value if desired.
  - Improved handling of arrays that start with NaN values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->